### PR TITLE
Fix: Disable Turbopack for cPanel symlink compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --no-turbopack",
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",


### PR DESCRIPTION
Turbopack crashes on cPanel because node_modules is a symlink pointing outside the filesystem root. Use Webpack instead.