### PR TITLE
Fix: cPanel build — cpanel-build.sh fixes symlinked node_modules

### DIFF
--- a/cpanel-entry.js
+++ b/cpanel-entry.js
@@ -1,20 +1,18 @@
 /**
  * cPanel Node.js App entry point.
  *
- * cPanel's Phusion Passenger for Node.js sets the PORT environment variable.
- * Next.js `next start` reads PORT automatically.
- * This file simply invokes `next start` programmatically.
+ * Before first run, execute: bash scripts/cpanel-build.sh
+ * This fixes the symlinked node_modules and runs next build.
+ *
+ * Passenger sets PORT automatically.
  */
-const { execSync } = require('child_process');
+const { spawn } = require("child_process");
+
 const port = process.env.PORT || 3000;
 
-process.env.PORT = String(port);
-require('next/dist/server/lib/start-server');
-
-// Fallback: run next start as child process
-const { spawn } = require('child_process');
-const next = spawn('npx', ['next', 'start', '-p', String(port)], {
-  stdio: 'inherit',
+const server = spawn("npx", ["next", "start", "-p", String(port)], {
+  stdio: "inherit",
   env: { ...process.env, PORT: String(port) },
 });
-next.on('close', (code) => process.exit(code));
+
+server.on("close", (code) => process.exit(code));

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build --no-turbopack",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",

--- a/scripts/cpanel-build.sh
+++ b/scripts/cpanel-build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Fix cPanel symlinked node_modules before Next.js build.
+#
+# cPanel Setup Node.js creates node_modules as a symlink pointing to
+# a virtual environment directory. Turbopack (Next.js 16 default bundler)
+# rejects symlinks that point outside the project root.
+#
+# This script replaces the symlink with a real copy, then builds.
+# Run this from cPanel terminal or via "Run Script" after npm install.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Fix symlinked node_modules
+if [ -L "node_modules" ]; then
+  TARGET=$(readlink -f node_modules)
+  echo "Replacing node_modules symlink -> $TARGET"
+  rm node_modules
+  cp -r "$TARGET" node_modules
+  echo "node_modules is now a real directory"
+fi
+
+echo "Building Next.js..."
+npm run build
+
+echo "Build complete."


### PR DESCRIPTION
Turbopack rejects cPanel's symlinked node_modules. scripts/cpanel-build.sh replaces the symlink with a real directory copy before running next build.