### PR TITLE
Fix: Source Node.js env for npm in cPanel build script

### DIFF
--- a/scripts/cpanel-build.sh
+++ b/scripts/cpanel-build.sh
@@ -12,6 +12,14 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# Source cPanel Node.js environment (adds npm/node to PATH)
+NODEVENV="$HOME/nodevenv/public_html/minepile.fasl-work.com/24"
+if [ -f "$NODEVENV/bin/activate" ]; then
+  source "$NODEVENV/bin/activate"
+elif [ -d "$NODEVENV/bin" ]; then
+  export PATH="$NODEVENV/bin:$PATH"
+fi
+
 # Fix symlinked node_modules
 if [ -L "node_modules" ]; then
   TARGET=$(readlink -f node_modules)


### PR DESCRIPTION
npm not found because cPanel bash session lacks Node.js PATH. Script now sources the nodevenv activate.