### PR TITLE
Fix: Skip activate, add Node bin to PATH directly

### DIFF
--- a/scripts/cpanel-build.sh
+++ b/scripts/cpanel-build.sh
@@ -12,13 +12,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Source cPanel Node.js environment (adds npm/node to PATH)
+# Add cPanel Node.js to PATH (skip activate script — it has unbound vars)
 NODEVENV="$HOME/nodevenv/public_html/minepile.fasl-work.com/24"
-if [ -f "$NODEVENV/bin/activate" ]; then
-  source "$NODEVENV/bin/activate"
-elif [ -d "$NODEVENV/bin" ]; then
-  export PATH="$NODEVENV/bin:$PATH"
-fi
+export PATH="$NODEVENV/bin:$PATH"
 
 # Fix symlinked node_modules
 if [ -L "node_modules" ]; then


### PR DESCRIPTION
cPanel activate script has unbound variables incompatible with set -u.