### PR TITLE
[codex] Add local setup and exporter documentation helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ Thumbs.db
 
 # TypeScript
 *.tsbuildinfo
+
+# Python
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ types/
 
 ## Current Version
 
-`1.00.013`
+`1.00.017`
 
 Versioning uses the fixed-width format `x.xx.xxx`.
 This stable baseline corresponds semantically to the `1.0.0` release milestone.

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ types/
 - [App Data Contract](docs/app-data-contract.md)
 - [Development Guidelines](docs/development-guidelines.md)
 - [Local Runtime Guide](docs/local-runtime-guide.md)
+pr - [Exporter Script Docs](scripts/docs/generate-actual-cache.md)
 - [Changelog](CHANGELOG.md)
 
 ## Current Version

--- a/scripts/docs/README.md
+++ b/scripts/docs/README.md
@@ -1,0 +1,8 @@
+# Scripts Docs
+
+This folder documents the tracked maintenance scripts under `scripts/`, with emphasis on the raw-data-to-app-cache conversion path that feeds the application runtime.
+
+Current documents:
+
+- [generate-actual-cache.md](./generate-actual-cache.md)
+  Documents how `scripts/generate_actual_cache.py` converts `data/` into the app-ready cache used by the web application for circuit, live MTO state, profiler history, and simulator steps.

--- a/scripts/docs/generate-actual-cache.md
+++ b/scripts/docs/generate-actual-cache.md
@@ -1,0 +1,594 @@
+# `generate_actual_cache.py`
+
+## Purpose
+
+`scripts/generate_actual_cache.py` is the tracked exporter that converts the local raw dataset under `data/` into the app-ready cache consumed by the Next.js application.
+
+It exists for three reasons:
+
+- to keep normal application runtime independent from raw simulation artifacts
+- to reshape raw model outputs into route-specific payloads that the UI can consume directly
+- to enforce one stable conversion boundary that can be rebuilt, validated, and debugged explicitly
+
+Normal runtime does **not** read the raw dataset directly. It reads only the generated cache under:
+
+```text
+.local/app-data/v1/
+```
+
+or another root provided through `APP_CACHE_ROOT` / `APP_DATA_ROOT`.
+
+## Execution Path
+
+The expected repository-owned entry point is:
+
+```powershell
+pnpm cache:rebuild
+```
+
+That command resolves into this chain:
+
+1. `scripts/cache-rebuild.ts`
+2. `lib/server/app-cache-rebuild.ts`
+3. `scripts/generate_actual_cache.py`
+
+The TypeScript layer is only a launcher:
+
+- parses `--root` and `--raw-root`
+- resolves the Python executable
+- passes `APP_CACHE_ROOT` and `RAW_DATA_ROOT`
+
+The Python script performs the actual transformation.
+
+## Responsibility Split By Script
+
+| File | Responsibility |
+|---|---|
+| `scripts/cache-rebuild.ts` | repository-owned CLI entry point used by `pnpm cache:rebuild` |
+| `lib/server/app-cache-rebuild.ts` | argument parsing, Python launcher resolution, and environment wiring |
+| `scripts/generate_actual_cache.py` | actual raw-data-to-cache conversion logic |
+| `scripts/local/rebuild-local-app-data.ps1` | local PowerShell wrapper around the tracked rebuild path |
+
+## Required Raw Inputs
+
+The exporter fails fast if these inputs are missing:
+
+```text
+<RAW_DATA_ROOT>/
+  conf/qualities.yml
+  conf/mto_objects.yml
+  05_model_input/sequence.json
+  06_models/mt_state.joblib
+  08_reporting/
+```
+
+It also expects:
+
+- `04_feature/df_transport.pkl` for simulator rate derivation
+- the Python packages listed in `scripts/generate_actual_cache.requirements.txt`
+- the reference `mineral_tracking` module to be importable when unpickling `mt_state.joblib`
+
+If the reference module is not available in the default fallback path, `REFERENCE_ROOT` must point to the source tree that contains it.
+
+## High-Level Conversion Flow
+
+```text
+data/conf/qualities.yml          -> qualities.json
+data/conf/mto_objects.yml        -> registry.json, circuit.json, live pile metadata, simulator output config
+data/05_model_input/sequence.json -> stageIndex values and staged circuit layout
+data/06_models/mt_state.joblib   -> live belts, live piles, live summaries
+data/08_reporting/**/history     -> profiler snapshots, profiler manifests, profiler summary
+data/08_reporting/**/sims        -> simulator future steps
+data/04_feature/df_transport.pkl -> simulator tonsPerStep / tonsPerHour
+```
+
+The script then writes:
+
+- top-level manifest and metadata
+- circuit graph
+- current live MTO payloads
+- profiler history payloads
+- simulator payloads
+
+## What The App Needs From This Conversion
+
+The exporter is not producing one generic dataset. It is producing four different runtime views over the same raw source tree:
+
+| App area | Why the exported payload exists |
+|---|---|
+| `Circuit` | the UI needs a staged structural graph with enriched pile anchors instead of raw configuration files |
+| `Live` | the UI needs dense current belt blocks and pile cells already normalized into Arrow rows |
+| `Profiler` | the UI needs summarized historical snapshots that can be paged and compared efficiently |
+| `Simulator` | the UI needs pile-centered future-step payloads plus output projections, not only raw `sims` parquet files |
+
+That is why the exporter builds different shapes for the different workspaces instead of exposing the raw folders directly.
+
+## Shared Metadata Built First
+
+Before the route-specific areas are exported, the script builds the metadata that all routes depend on.
+
+### Quality definitions
+
+`build_quality_definitions()` reads `conf/qualities.yml` and emits:
+
+- numerical quality definitions with min/max and display palette
+- categorical quality definitions with categories, colors, and display labels
+
+These become:
+
+```text
+qualities.json
+```
+
+### Object registry
+
+`build_registry()` reads the loaded `mt_state` together with `mto_objects.yml` and `sequence.json` to produce:
+
+- `objectId`
+- `objectType` (`belt` / `pile`)
+- `objectRole` (`physical` / `virtual`)
+- `displayName`
+- `shortDescription`
+- `dimension`
+- `isProfiled`
+- route payload references such as `liveRef`, `livePileRef`, and `profilerRef`
+- `stageIndex`
+
+This becomes:
+
+```text
+registry.json
+```
+
+The registry is the central lookup layer that connects object identity to route-specific files.
+
+### Why registry comes first
+
+The rest of the export depends on a stable object inventory:
+
+- the circuit graph needs object identity and dimensionality
+- live summaries need display names and object roles
+- profiler and simulator manifests need route references and display metadata
+
+If the registry were inconsistent, every route would drift separately.
+
+## Circuit Export
+
+### Source inputs
+
+Circuit export depends mainly on:
+
+- `registry`
+- `conf/mto_objects.yml`
+- `05_model_input/sequence.json`
+
+### Main function
+
+```text
+build_circuit_graph()
+```
+
+### What it derives
+
+For each registered object, the script builds:
+
+- staged circuit nodes
+- directed edges
+- pile input anchors
+- pile output anchors
+
+Anchor geometry is not copied blindly. The exporter normalizes and enriches it:
+
+- `x` and `y` are derived from `col_x` / `col_y`
+- non-numeric dynamic anchor coordinates fall back to `0.5`
+- `positionMode` becomes `"assumed-center"` when a dynamic value had to be normalized
+- `spanX` and `spanY` are derived from configured feed/discharge neighborhood fractions, or from dimension-aware defaults when the config is incomplete
+
+### Output
+
+```text
+circuit.json
+```
+
+This file is what `/circuit` uses to render:
+
+- stage grouping
+- structural connectivity
+- feed/discharge anchor context
+
+### Why circuit gets a dedicated export
+
+The raw source data is not already shaped as a UI graph. The app needs:
+
+- one node inventory aligned with route object ids
+- explicit edges
+- one stable stage index per object
+- pile-relative anchor geometry
+
+The exporter turns configuration and sequence data into that graph-ready structure.
+
+## Live Export: Current MTO State
+
+The live export is the current dense state taken from `06_models/mt_state.joblib`.
+
+### Belt export
+
+#### Main function
+
+```text
+build_belt_records()
+```
+
+#### Source
+
+For each belt, the exporter reads:
+
+```text
+belt.mto_current
+```
+
+Only rows with positive occupancy are kept:
+
+```text
+belt.mto_current[belt.mto_current[:, 0] > 0]
+```
+
+Each output row contains:
+
+- `position`
+- `massTon`
+- `timestampOldestMs`
+- `timestampNewestMs`
+- one field per quality id
+
+#### Outputs
+
+```text
+live/belts/<belt_id>.arrow
+live/object-summaries.json
+```
+
+The live summary for belts is built with `build_live_summary()` and uses mass-weighted quality averages.
+
+### Why belts are exported this way
+
+The live belt route reads one dense belt snapshot at a time. That route needs:
+
+- rows already ordered by belt position
+- mass and represented-material timestamps per block
+- route-level summary values that can be shown without loading every dense artifact first
+
+### Pile export
+
+#### Main functions
+
+```text
+build_pile_cell_records()
+build_surface_records()
+build_stockpile_metadata()
+```
+
+#### Source
+
+For each pile, the exporter reads:
+
+```text
+pile.internal_pile
+```
+
+Only occupied cells are emitted. Each output row contains:
+
+- `ix`
+- `iy`
+- `iz`
+- `massTon`
+- `timestampOldestMs`
+- `timestampNewestMs`
+- one field per quality id
+
+#### Metadata derived for the app
+
+The script derives:
+
+- effective dimensionality
+- `extents`
+- `occupiedCellCount`
+- `surfaceCellCount`
+- default and available quality ids
+- allowed view modes
+- `suggestedFullStride`
+- `fullModeThreshold`
+- mass-weighted `qualityAverages`
+- input/output anchors
+
+For `3D` piles it currently emits:
+
+- `surface`
+- `shell`
+- `full`
+- `slice`
+
+as route-supported `viewModes`.
+
+#### Outputs
+
+```text
+live/piles/<pile_id>/meta.json
+live/piles/<pile_id>/cells.arrow
+live/piles/<pile_id>/surface.arrow
+live/piles/<pile_id>/shell.arrow
+live/object-summaries.json
+```
+
+Note:
+
+- `surface.arrow` is derived as the top occupied cell per `(ix, iy)` column
+- `shell.arrow` currently reuses `surface_records`
+
+That means the current exporter does **not** build a separate shell extraction algorithm yet; it emits a shell-compatible acceleration artifact using the same outer surface rows.
+
+### Why live summaries exist
+
+`live/object-summaries.json` is a compact overview used by the application alongside the dense per-object payloads. It gives the routes a fast way to display current object status and mass-weighted summary values without loading every heavy Arrow file up front.
+
+### Why live piles are exported this way
+
+The app needs more than a raw 3D tensor. It needs:
+
+- explicit extents
+- dimensionality
+- supported view modes
+- render safety hints such as `suggestedFullStride` and `fullModeThreshold`
+- input and output anchors for in-figure context
+
+That extra metadata is what lets the live route render the same pile correctly across `1D`, `2D`, and `3D` modes.
+
+## Profiler Export
+
+Profiler export is built from:
+
+```text
+data/08_reporting/<object_id>/<dimension>/
+```
+
+### Main functions
+
+```text
+pick_profile_files()
+summarize_profile_dataframe()
+profile_rows_from_dataframe()
+```
+
+### File selection
+
+The exporter looks for:
+
+- `profile_latest.parquet`
+- `history/profile_*.parquet`
+
+Special case:
+
+- for `pile_stockpile`, historical sampling is downsampled using `PILE_HISTORY_STRIDE = 12`
+
+This is a deliberate performance and volume control for the largest historical pile.
+
+### Summary semantics
+
+For each selected profiler parquet file, the exporter derives:
+
+- one summary row for `profiler/summary.arrow`
+- one dense summarized snapshot for `profiler/objects/<object_id>/snapshots/<snapshot_id>.arrow`
+- one object manifest
+
+Numerical qualities use:
+
+- weighted average when `mass_ton` is available
+- arithmetic mean only as fallback
+
+Categorical qualities use:
+
+- mass-weighted dominant category when weights exist
+- first non-null categorical value as fallback
+
+### Outputs
+
+```text
+profiler/index.json
+profiler/summary.arrow
+profiler/objects/<object_id>/manifest.json
+profiler/objects/<object_id>/snapshots/<snapshot_id>.arrow
+```
+
+These are the files consumed by `/profiler`.
+
+### Why profiler is exported separately from live state
+
+Profiler is not a second live route. It is a historical summarized route. The app therefore needs:
+
+- one compact summary table to drive object/time selection
+- one manifest per object
+- one normalized snapshot payload per selected historical step
+
+The exporter makes that distinction explicit by separating profiler outputs from `live/`.
+
+## Simulator Export
+
+Simulator export is built only for pile objects that:
+
+- are present in the registry
+- have profiler history
+- have `profile_latest.parquet`
+
+### Main functions
+
+```text
+pick_sim_files()
+infer_step_minutes()
+build_transport_rate_map()
+build_simulator_output_records()
+```
+
+### Source inputs
+
+Simulator export combines three raw sources:
+
+1. latest profiler state from `profile_latest.parquet`
+2. future simulated steps from `sims/profile_*.parquet`
+3. latest transport row from `04_feature/df_transport.pkl`
+
+### Step construction
+
+Each simulator object gets a step list composed of:
+
+- a `"base"` step from `profile_latest.parquet`
+- zero or more `"simulated"` steps from `sims/`
+
+For every step, the exporter writes:
+
+- one pile snapshot under `simulator/.../pile.arrow`
+- one output snapshot per configured pile output under `simulator/.../outputs/<output_id>.arrow`
+
+### How output rates are derived
+
+`build_transport_rate_map()` calculates:
+
+- `tonsPerStep`
+- `tonsPerHour`
+- `parentBeltId`
+
+It uses:
+
+- direct `tag_ton` values when the transport dataframe exposes them
+- proportional splits through `conf_prop_belts` when virtual feeder outputs inherit from one measured parent belt
+
+### How simulated output blocks are generated
+
+`build_simulator_output_records()` does not read downstream raw belt snapshots.
+
+Instead, it synthesizes output blocks by consuming mass from the simulated pile rows:
+
+- preferred cells are those inside the configured output footprint
+- fallback candidates are all remaining pile cells
+- candidates are ordered by `iz`, normalized distance to the output anchor, then `ix`/`iy`
+- the function removes mass progressively from the remaining pile mass budget while creating output blocks
+
+This means simulator outputs are generated as a projection of the simulated pile state plus configured reclaim rates, not as a separately measured downstream simulation artifact.
+
+### Outputs
+
+```text
+simulator/index.json
+simulator/objects/<object_id>/manifest.json
+simulator/objects/<object_id>/steps/<snapshot_id>/pile.arrow
+simulator/objects/<object_id>/steps/<snapshot_id>/outputs/<output_id>.arrow
+```
+
+These are the files consumed by `/simulator`.
+
+### Why simulator needs its own export
+
+The simulator route is not reading raw `sims` files directly. It needs:
+
+- one pile-centered manifest
+- one ordered list of time steps
+- one pile payload per step
+- one output projection per configured reclaim/output
+- discharge-rate context already converted into `tonsPerStep` and `tonsPerHour`
+
+The exporter packages those decisions into a route-ready shape so the UI can stay focused on reading, not on recomputing scenario structure in the browser.
+
+## Final Top-Level Manifest
+
+After all route payloads are written, the exporter emits:
+
+```text
+manifest.json
+qualities.json
+registry.json
+circuit.json
+live/object-summaries.json
+profiler/index.json
+profiler/summary.arrow
+simulator/index.json
+```
+
+The manifest currently advertises these capabilities:
+
+- `circuit`
+- `live`
+- `stockpiles`
+- `profiler`
+- `simulator`
+
+`stockpiles` remains enabled as a compatibility surface even though the active product model treats dense pile reading as part of `Live > Piles / VPiles`.
+
+## Operational Notes
+
+### Destructive behavior at the cache root
+
+The exporter deletes the target app-cache root before rebuilding it:
+
+```python
+if APP_ROOT.exists():
+    shutil.rmtree(APP_ROOT)
+```
+
+That is expected behavior. The script rebuilds the app-ready cache from scratch.
+
+### Version propagation
+
+The generated manifest writes:
+
+```text
+appVersion = package.json version
+```
+
+through `read_app_version()`.
+
+This is what later allows:
+
+- `/diagnostics`
+- `pnpm cache:check`
+
+to detect cache-version drift against the repository.
+
+### Default dataset label
+
+The exporter currently writes:
+
+```text
+datasetLabel = "Local converted dataset"
+```
+
+If richer dataset labeling is needed later, this is one obvious extension point.
+
+## Extension Guidelines
+
+When changing this exporter, keep these rules in mind:
+
+- preserve the runtime boundary: do not make the UI depend on raw `data/` files
+- keep route semantics separated: live, profiler, and simulator should not silently collapse into one generic payload family
+- update `docs/app-data-contract.md` if the app-ready contract changes
+- update `scripts/docs/generate-actual-cache.md` when conversion rules change materially
+- prefer adding small helper functions when a new conversion rule would otherwise duplicate logic across route areas
+
+## Troubleshooting Checklist
+
+If the exporter fails or the rebuilt cache behaves unexpectedly, check these first:
+
+1. `RAW_DATA_ROOT` points to the intended dataset
+2. `REFERENCE_ROOT` exposes the `mineral_tracking` module when required
+3. the selected Python environment has the packages from `scripts/generate_actual_cache.requirements.txt`
+4. `data/08_reporting` contains the expected profiler and `sims` parquet files
+5. `pnpm cache:check` or `pnpm cache:check:deep` passes after rebuild
+
+## Practical Summary
+
+If you need to understand the route data sources in one sentence each:
+
+- `Circuit` comes from `registry + sequence + object configuration`
+- `Live` comes from the latest `mt_state.joblib`
+- `Profiler` comes from `08_reporting/.../history` plus `profile_latest.parquet`
+- `Simulator` comes from `profile_latest.parquet + sims/*.parquet + latest transport rates`
+
+That is the conversion boundary between `data/` and the runtime cache used by the app.

--- a/scripts/generate_actual_cache.py
+++ b/scripts/generate_actual_cache.py
@@ -1,3 +1,10 @@
+"""Export the local raw mineral-tracking dataset into the app-ready runtime cache.
+
+This script is the only tracked conversion boundary between `data/` and the cache
+consumed by the Next.js application. It emits the shared metadata plus the route
+payloads used by the circuit, live, profiler, and simulator workspaces.
+"""
+
 from __future__ import annotations
 
 import json
@@ -32,6 +39,7 @@ PILE_HISTORY_STRIDE = 12
 
 
 def detect_reference_root() -> Path | None:
+    """Resolve the optional source tree that provides the `mineral_tracking` module."""
     configured = os.environ.get("REFERENCE_ROOT")
     candidates: list[Path] = []
 
@@ -307,6 +315,7 @@ def build_live_summary(
 
 
 def build_registry(state, objects_conf: dict[str, Any], report_root: Path) -> list[dict[str, Any]]:
+    """Build one app registry entry per current belt or pile object."""
     registry: list[dict[str, Any]] = []
     pile_confs = {
         **objects_conf["objects"].get("piles", {}),
@@ -366,6 +375,7 @@ def build_registry(state, objects_conf: dict[str, Any], report_root: Path) -> li
 
 
 def build_circuit_graph(registry: list[dict[str, Any]], objects_conf: dict[str, Any]) -> dict[str, Any]:
+    """Derive the staged circuit graph and pile anchors used by the circuit route."""
     registry_map = {entry["objectId"]: entry for entry in registry}
     nodes = []
     edges = []
@@ -454,6 +464,7 @@ def build_circuit_graph(registry: list[dict[str, Any]], objects_conf: dict[str, 
 
 
 def build_belt_records(belt, quality_ids: list[str]) -> tuple[list[dict[str, Any]], list[dict[str, float | None]], list[float]]:
+    """Convert the current occupied belt blocks into live Arrow-ready rows."""
     records = []
     quality_maps = []
     masses = []
@@ -478,6 +489,7 @@ def build_belt_records(belt, quality_ids: list[str]) -> tuple[list[dict[str, Any
 
 
 def build_pile_cell_records(pile, quality_ids: list[str]) -> tuple[list[dict[str, Any]], list[dict[str, float | None]], list[float]]:
+    """Convert the occupied pile cells into live Arrow-ready rows."""
     internal = pile.internal_pile
     used = internal[:, 0, :, :] > 0
     indices = np.argwhere(used)
@@ -507,6 +519,7 @@ def build_pile_cell_records(pile, quality_ids: list[str]) -> tuple[list[dict[str
 
 
 def build_surface_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep only the highest occupied cell in each `(ix, iy)` column."""
     top_map: dict[tuple[int, int], dict[str, Any]] = {}
     for record in records:
         key = (record["ix"], record["iy"])
@@ -526,6 +539,7 @@ def build_stockpile_metadata(
     quality_ids: list[str],
     registry_map: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
+    """Build the live pile metadata used to describe dense pile payloads to the app."""
     dimension = registry_map[pile_id]["dimension"]
     configured_x, configured_y = get_configured_xy_extents(pile_conf, dimension)
     extents_x = max(configured_x, max((record["ix"] for record in records), default=-1) + 1)
@@ -568,6 +582,7 @@ def build_stockpile_metadata(
 
 
 def pick_profile_files(object_id: str, dim_folder: Path) -> list[Path]:
+    """Select the profiler parquet files that should become app snapshots."""
     latest = dim_folder / "profile_latest.parquet"
     history = sorted((dim_folder / "history").glob("profile_*.parquet"))
     if object_id == "pile_stockpile":
@@ -614,6 +629,7 @@ def build_transport_rate_map(
     latest_transport_row: pd.Series,
     step_minutes: int,
 ) -> dict[str, dict[str, Any]]:
+    """Derive simulator discharge rates from the latest transport measurements."""
     belts_conf = {
         **objects_conf["objects"].get("belts", {}),
         **objects_conf["objects"].get("vbelts", {}),
@@ -715,6 +731,7 @@ def build_simulator_output_records(
     outputs: list[dict[str, Any]],
     quality_ids: list[str],
 ) -> dict[str, list[dict[str, Any]]]:
+    """Project simulated output blocks by consuming mass from the simulated pile rows."""
     extents = {
         "x": max((int(record.get("ix", 0)) for record in pile_records), default=0) + 1,
         "y": max((int(record.get("iy", 0)) for record in pile_records), default=0) + 1,
@@ -782,6 +799,7 @@ def summarize_profile_dataframe(
     numerical_ids: list[str],
     categorical_ids: list[str],
 ) -> dict[str, Any]:
+    """Collapse one profiler parquet snapshot into a single summary row."""
     mass = float(df["mass_ton"].sum()) if "mass_ton" in df.columns else 0.0
     timestamp = pd.Timestamp(df["timestamp"].iloc[0]).isoformat()
     weights = df["mass_ton"] if "mass_ton" in df.columns else pd.Series([1.0] * len(df))
@@ -817,6 +835,7 @@ def summarize_profile_dataframe(
 
 
 def profile_rows_from_dataframe(df: pd.DataFrame, quality_ids: list[str], dimension: int) -> list[dict[str, Any]]:
+    """Normalize profiler or simulator parquet rows into pile-style cell records."""
     rows = []
     for _, record in df.iterrows():
         row = {
@@ -836,6 +855,7 @@ def profile_rows_from_dataframe(df: pd.DataFrame, quality_ids: list[str], dimens
 
 
 def ensure_required_paths() -> None:
+    """Fail fast when the configured raw dataset is incomplete."""
     if not RAW_ROOT.exists():
         raise FileNotFoundError(
             f"Configured RAW_DATA_ROOT does not exist: {RAW_ROOT}. Set RAW_DATA_ROOT or place the dataset under {PROJECT_ROOT / 'data'}."
@@ -857,6 +877,7 @@ def ensure_required_paths() -> None:
 
 
 def ensure_reference_modules() -> None:
+    """Ensure the reference module required to unpickle the raw model state is importable."""
     if importlib.util.find_spec("mineral_tracking") is not None:
         return
 
@@ -880,6 +901,7 @@ def ensure_reference_modules() -> None:
 
 
 def main() -> None:
+    """Rebuild the app-ready cache from scratch under the selected app root."""
     ensure_required_paths()
     ensure_reference_modules()
 

--- a/scripts/local/install-local-requirements.ps1
+++ b/scripts/local/install-local-requirements.ps1
@@ -1,0 +1,252 @@
+param(
+  [string]$PythonBin,
+  [switch]$SkipNodeInstall,
+  [switch]$SkipPythonInstall,
+  [switch]$IncludePlaywrightBrowsers,
+  [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param(
+    [string]$PathValue,
+    [string]$BaseDirectory
+  )
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    throw 'Path value cannot be empty.'
+  }
+
+  if ([System.IO.Path]::IsPathRooted($PathValue)) {
+    return [System.IO.Path]::GetFullPath($PathValue)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BaseDirectory $PathValue))
+}
+
+function Get-PnpmCommand {
+  if (Get-Command 'pnpm.cmd' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'pnpm.cmd'
+      Prefix = @()
+    }
+  }
+
+  if (Get-Command 'pnpm' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'pnpm'
+      Prefix = @()
+    }
+  }
+
+  if (Get-Command 'corepack' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'corepack'
+      Prefix = @('pnpm')
+    }
+  }
+
+  throw 'Could not find pnpm, pnpm.cmd, or corepack in PATH.'
+}
+
+function Get-PythonCommand {
+  param(
+    [string]$PythonOverride
+  )
+
+  $configuredPython = if ($PythonOverride) {
+    $PythonOverride.Trim()
+  } elseif ($env:PYTHON_BIN) {
+    $env:PYTHON_BIN.Trim()
+  } else {
+    ''
+  }
+
+  if ($configuredPython) {
+    return @{
+      Exe = $configuredPython
+      Prefix = @()
+    }
+  }
+
+  if (Get-Command 'python' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'python'
+      Prefix = @()
+    }
+  }
+
+  if (Get-Command 'py' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'py'
+      Prefix = @('-3')
+    }
+  }
+
+  if (Get-Command 'python3' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'python3'
+      Prefix = @()
+    }
+  }
+
+  throw 'Could not find python, py, or python3 in PATH. Install Python 3 or pass -PythonBin.'
+}
+
+function Get-NodeVersionInfo {
+  if (-not (Get-Command 'node' -ErrorAction SilentlyContinue)) {
+    throw 'Could not find Node.js in PATH. Install a supported Node.js version before running this script.'
+  }
+
+  $rawVersion = (& node --version).Trim()
+  if ($rawVersion -notmatch '^v?(?<major>\d+)(\.\d+){0,2}.*$') {
+    throw "Could not parse Node.js version '$rawVersion'."
+  }
+
+  return @{
+    Raw = $rawVersion
+    Major = [int]$Matches['major']
+  }
+}
+
+function Assert-NodeVersion {
+  param(
+    [hashtable]$NodeVersionInfo,
+    [string]$Constraint
+  )
+
+  if ($Constraint -notmatch '>=\s*(?<min>\d+)\s*<\s*(?<max>\d+)') {
+    return
+  }
+
+  $minMajor = [int]$Matches['min']
+  $maxMajor = [int]$Matches['max']
+
+  if ($NodeVersionInfo.Major -lt $minMajor -or $NodeVersionInfo.Major -ge $maxMajor) {
+    throw "Unsupported Node.js version $($NodeVersionInfo.Raw). This repo expects $Constraint."
+  }
+}
+
+function Format-CommandLine {
+  param(
+    [string]$Exe,
+    [string[]]$Arguments
+  )
+
+  return @($Exe) + $Arguments -join ' '
+}
+
+function Invoke-ExternalCommand {
+  param(
+    [string]$Exe,
+    [string[]]$Arguments,
+    [switch]$DryRun
+  )
+
+  Write-Host "> $(Format-CommandLine -Exe $Exe -Arguments $Arguments)"
+  if (-not $DryRun) {
+    & $Exe @Arguments
+  }
+}
+
+function Invoke-Pnpm {
+  param(
+    [hashtable]$PnpmCommand,
+    [string[]]$Arguments,
+    [switch]$DryRun
+  )
+
+  Invoke-ExternalCommand `
+    -Exe $PnpmCommand.Exe `
+    -Arguments @($PnpmCommand.Prefix + $Arguments) `
+    -DryRun:$DryRun
+}
+
+function Invoke-Python {
+  param(
+    [hashtable]$PythonCommand,
+    [string[]]$Arguments,
+    [switch]$DryRun
+  )
+
+  Invoke-ExternalCommand `
+    -Exe $PythonCommand.Exe `
+    -Arguments @($PythonCommand.Prefix + $Arguments) `
+    -DryRun:$DryRun
+}
+
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptDirectory '..\..')).Path
+$defaultAppDataRoot = Resolve-AbsolutePath -PathValue '.local\app-data\v1' -BaseDirectory $repoRoot
+$defaultRawDataRoot = Resolve-AbsolutePath -PathValue 'data' -BaseDirectory $repoRoot
+
+Push-Location $repoRoot
+try {
+  $packageJson = Get-Content -Raw 'package.json' | ConvertFrom-Json
+  $nodeVersionInfo = Get-NodeVersionInfo
+  Assert-NodeVersion -NodeVersionInfo $nodeVersionInfo -Constraint $packageJson.engines.node
+
+  $pnpmCommand = Get-PnpmCommand
+  $pythonCommand = $null
+  if (-not $SkipPythonInstall) {
+    $pythonCommand = Get-PythonCommand -PythonOverride $PythonBin
+  }
+
+  Write-Host "Repo root: $repoRoot"
+  Write-Host "Node.js: $($nodeVersionInfo.Raw)"
+  Write-Host "Node engine: $($packageJson.engines.node)"
+  Write-Host "pnpm launcher: $(Format-CommandLine -Exe $pnpmCommand.Exe -Arguments $pnpmCommand.Prefix)"
+  if ($pythonCommand) {
+    Write-Host "Python launcher: $(Format-CommandLine -Exe $pythonCommand.Exe -Arguments $pythonCommand.Prefix)"
+  }
+
+  if (-not $SkipNodeInstall) {
+    Write-Host ''
+    Write-Host 'Installing Node.js dependencies from package.json and pnpm-lock.yaml...'
+    Invoke-Pnpm -PnpmCommand $pnpmCommand -Arguments @('install') -DryRun:$DryRun
+  }
+
+  if (-not $SkipPythonInstall) {
+    Write-Host ''
+    Write-Host 'Installing Python dependencies for the tracked raw-data exporter...'
+    Invoke-Python `
+      -PythonCommand $pythonCommand `
+      -Arguments @('-m', 'pip', 'install', '-r', 'scripts/generate_actual_cache.requirements.txt') `
+      -DryRun:$DryRun
+  }
+
+  if ($IncludePlaywrightBrowsers) {
+    Write-Host ''
+    Write-Host 'Installing Playwright browsers for end-to-end validation...'
+    Invoke-Pnpm -PnpmCommand $pnpmCommand -Arguments @('exec', 'playwright', 'install') -DryRun:$DryRun
+  }
+
+  Write-Host ''
+  Write-Host 'Local next steps:'
+  if (Test-Path -LiteralPath $defaultRawDataRoot) {
+    Write-Host '  1. Rebuild the local app-ready cache from the raw data folder:'
+    Write-Host '     powershell -ExecutionPolicy Bypass -File scripts/local/rebuild-local-app-data.ps1'
+  } elseif (-not (Test-Path -LiteralPath $defaultAppDataRoot)) {
+    Write-Host '  1. Provide a raw dataset under data\ or point the rebuild script at another raw root.'
+    Write-Host '     A clean clone does not include data\ or .local\ because both are gitignored.'
+  }
+
+  if (Test-Path -LiteralPath $defaultAppDataRoot) {
+    Write-Host '  2. Start the local application with the managed dev-server wrapper:'
+  } else {
+    Write-Host '  2. Start the local application after a cache has been created or APP_DATA_ROOT points to one:'
+  }
+  Write-Host '     powershell -ExecutionPolicy Bypass -File scripts/local/start-local-app.ps1'
+
+  if (-not $IncludePlaywrightBrowsers) {
+    Write-Host ''
+    Write-Host 'Optional:'
+    Write-Host '  Install browser binaries later with:'
+    Write-Host '     powershell -ExecutionPolicy Bypass -File scripts/local/install-local-requirements.ps1 -IncludePlaywrightBrowsers'
+  }
+}
+finally {
+  Pop-Location
+}

--- a/scripts/local/rebuild-local-app-data.ps1
+++ b/scripts/local/rebuild-local-app-data.ps1
@@ -1,0 +1,275 @@
+param(
+  [string]$RawDataRoot = 'data',
+  [string]$AppDataRoot = '.local\app-data\v1',
+  [string]$ReferenceRoot,
+  [string]$PythonBin,
+  [switch]$InstallPythonDependencies,
+  [switch]$SkipValidation,
+  [switch]$DeepValidation,
+  [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param(
+    [string]$PathValue,
+    [string]$BaseDirectory
+  )
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    throw 'Path value cannot be empty.'
+  }
+
+  if ([System.IO.Path]::IsPathRooted($PathValue)) {
+    return [System.IO.Path]::GetFullPath($PathValue)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BaseDirectory $PathValue))
+}
+
+function Get-PnpmCommand {
+  if (Get-Command 'pnpm.cmd' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'pnpm.cmd'
+      Prefix = @()
+    }
+  }
+
+  if (Get-Command 'pnpm' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'pnpm'
+      Prefix = @()
+    }
+  }
+
+  if (Get-Command 'corepack' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'corepack'
+      Prefix = @('pnpm')
+    }
+  }
+
+  throw 'Could not find pnpm, pnpm.cmd, or corepack in PATH.'
+}
+
+function Get-PythonCommand {
+  param(
+    [string]$PythonOverride
+  )
+
+  $configuredPython = if ($PythonOverride) {
+    $PythonOverride.Trim()
+  } elseif ($env:PYTHON_BIN) {
+    $env:PYTHON_BIN.Trim()
+  } else {
+    ''
+  }
+
+  if ($configuredPython) {
+    return @{
+      Exe = $configuredPython
+      Prefix = @()
+    }
+  }
+
+  if (Get-Command 'python' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'python'
+      Prefix = @()
+    }
+  }
+
+  if (Get-Command 'py' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'py'
+      Prefix = @('-3')
+    }
+  }
+
+  if (Get-Command 'python3' -ErrorAction SilentlyContinue) {
+    return @{
+      Exe = 'python3'
+      Prefix = @()
+    }
+  }
+
+  throw 'Could not find python, py, or python3 in PATH. Install Python 3 or pass -PythonBin.'
+}
+
+function Format-CommandLine {
+  param(
+    [string]$Exe,
+    [string[]]$Arguments
+  )
+
+  return @($Exe) + $Arguments -join ' '
+}
+
+function Invoke-ExternalCommand {
+  param(
+    [string]$Exe,
+    [string[]]$Arguments,
+    [switch]$DryRun
+  )
+
+  Write-Host "> $(Format-CommandLine -Exe $Exe -Arguments $Arguments)"
+  if (-not $DryRun) {
+    & $Exe @Arguments
+  }
+}
+
+function Invoke-Pnpm {
+  param(
+    [hashtable]$PnpmCommand,
+    [string[]]$Arguments,
+    [switch]$DryRun
+  )
+
+  Invoke-ExternalCommand `
+    -Exe $PnpmCommand.Exe `
+    -Arguments @($PnpmCommand.Prefix + $Arguments) `
+    -DryRun:$DryRun
+}
+
+function Invoke-Python {
+  param(
+    [hashtable]$PythonCommand,
+    [string[]]$Arguments,
+    [switch]$DryRun
+  )
+
+  Invoke-ExternalCommand `
+    -Exe $PythonCommand.Exe `
+    -Arguments @($PythonCommand.Prefix + $Arguments) `
+    -DryRun:$DryRun
+}
+
+function Assert-ExistingPath {
+  param(
+    [string]$TargetPath,
+    [string]$Label
+  )
+
+  if (-not (Test-Path -LiteralPath $TargetPath)) {
+    throw "$Label does not exist: $TargetPath"
+  }
+}
+
+function Assert-RawDatasetShape {
+  param(
+    [string]$RawRoot
+  )
+
+  $requiredPaths = @(
+    (Join-Path $RawRoot 'conf\qualities.yml'),
+    (Join-Path $RawRoot 'conf\mto_objects.yml'),
+    (Join-Path $RawRoot '05_model_input\sequence.json'),
+    (Join-Path $RawRoot '06_models\mt_state.joblib'),
+    (Join-Path $RawRoot '08_reporting')
+  )
+
+  $missingPaths = @($requiredPaths | Where-Object { -not (Test-Path -LiteralPath $_) })
+  if ($missingPaths.Count -gt 0) {
+    throw (
+      "The raw dataset is missing required files or folders:`n- " +
+      ($missingPaths -join "`n- ")
+    )
+  }
+}
+
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptDirectory '..\..')).Path
+$defaultAppDataRoot = Resolve-AbsolutePath -PathValue '.local\app-data\v1' -BaseDirectory $repoRoot
+$resolvedRawDataRoot = Resolve-AbsolutePath -PathValue $RawDataRoot -BaseDirectory $repoRoot
+$resolvedAppDataRoot = Resolve-AbsolutePath -PathValue $AppDataRoot -BaseDirectory $repoRoot
+$resolvedReferenceRoot = $null
+
+if ($ReferenceRoot) {
+  $resolvedReferenceRoot = Resolve-AbsolutePath -PathValue $ReferenceRoot -BaseDirectory $repoRoot
+}
+
+Push-Location $repoRoot
+try {
+  Assert-ExistingPath -TargetPath $resolvedRawDataRoot -Label 'Raw data root'
+  Assert-RawDatasetShape -RawRoot $resolvedRawDataRoot
+
+  if ($resolvedReferenceRoot) {
+    Assert-ExistingPath -TargetPath $resolvedReferenceRoot -Label 'Reference root'
+  }
+
+  $pnpmCommand = Get-PnpmCommand
+  $pythonCommand = $null
+  if ($InstallPythonDependencies) {
+    $pythonCommand = Get-PythonCommand -PythonOverride $PythonBin
+  }
+
+  if ($PythonBin) {
+    $env:PYTHON_BIN = $PythonBin.Trim()
+  }
+
+  if ($resolvedReferenceRoot) {
+    $env:REFERENCE_ROOT = $resolvedReferenceRoot
+  }
+
+  Write-Host "Repo root: $repoRoot"
+  Write-Host "RAW_DATA_ROOT: $resolvedRawDataRoot"
+  Write-Host "APP_CACHE_ROOT: $resolvedAppDataRoot"
+  Write-Host "pnpm launcher: $(Format-CommandLine -Exe $pnpmCommand.Exe -Arguments $pnpmCommand.Prefix)"
+  if ($env:PYTHON_BIN) {
+    Write-Host "PYTHON_BIN: $env:PYTHON_BIN"
+  }
+  if ($resolvedReferenceRoot) {
+    Write-Host "REFERENCE_ROOT: $resolvedReferenceRoot"
+  }
+
+  if ($InstallPythonDependencies) {
+    Write-Host ''
+    Write-Host 'Installing Python dependencies for the exporter before rebuilding the cache...'
+    Invoke-Python `
+      -PythonCommand $pythonCommand `
+      -Arguments @('-m', 'pip', 'install', '-r', 'scripts/generate_actual_cache.requirements.txt') `
+      -DryRun:$DryRun
+  }
+
+  Write-Host ''
+  Write-Host 'Rebuilding the tracked app-ready cache from the raw data tree...'
+  Invoke-Pnpm `
+    -PnpmCommand $pnpmCommand `
+    -Arguments @(
+      'cache:rebuild',
+      '--raw-root',
+      $resolvedRawDataRoot,
+      '--root',
+      $resolvedAppDataRoot
+    ) `
+    -DryRun:$DryRun
+
+  if (-not $SkipValidation) {
+    Write-Host ''
+    Write-Host 'Validating the regenerated cache...'
+    $validationCommand = if ($DeepValidation) {
+      @('cache:check:deep')
+    } else {
+      @('cache:check')
+    }
+
+    Invoke-Pnpm -PnpmCommand $pnpmCommand -Arguments $validationCommand -DryRun:$DryRun
+  }
+
+  Write-Host ''
+  if ($resolvedAppDataRoot -eq $defaultAppDataRoot) {
+    Write-Host 'The default local cache root is ready.'
+    Write-Host 'Start the app with:'
+    Write-Host '  powershell -ExecutionPolicy Bypass -File scripts/local/start-local-app.ps1'
+  } else {
+    Write-Host 'The cache was rebuilt into a non-default root.'
+    Write-Host 'Start the app with:'
+    Write-Host "  `$env:APP_DATA_ROOT = '$resolvedAppDataRoot'"
+    Write-Host '  powershell -ExecutionPolicy Bypass -File scripts/local/start-local-app.ps1'
+  }
+}
+finally {
+  Pop-Location
+}


### PR DESCRIPTION
## What changed
Added two PowerShell helpers under `scripts/local/` for clean-clone local setup and repo-managed app-data rebuild.

Added exporter documentation under `scripts/docs/` and linked it from `README.md`.

Added focused English docstrings to `scripts/generate_actual_cache.py` so the raw-data-to-cache boundary is easier to understand from the code itself.

Updated `.gitignore` to ignore Python bytecode artifacts generated during local validation.

## Why it changed
The repo already had a tracked cache rebuild workflow, but it still lacked:

- a clean local bootstrap path for a fresh clone
- a dedicated explanation of how raw `data/` becomes the app-ready cache consumed by the app
- in-code intent markers for the main exporter responsibilities

This also keeps the repository documentation aligned with the current tracked version and avoids accidental Python cache noise in git.

## Impact
Developers can now:

- install local requirements more directly
- rebuild `.local/app-data/v1/` from a raw dataset through repo-owned helpers
- understand how circuit, live MTO state, profiler history, and simulator payloads are exported
- inspect the exporter logic without reverse-engineering every function from scratch

## Validation
- Ran `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/local/install-local-requirements.ps1 -DryRun`
- Ran `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/local/rebuild-local-app-data.ps1 -DryRun`
- Ran `python -m py_compile scripts/generate_actual_cache.py`
- Left the unrelated local change in `next-env.d.ts` out of the commits
