### PR TITLE
fix(e2e): seed synthetic contract cache before the webServer boots

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "dev:stop": "tsx scripts/dev-server.ts stop",
     "dev:restart": "tsx scripts/dev-server.ts restart",
     "cache:rebuild": "tsx scripts/cache-rebuild.ts",
+    "seed:e2e": "tsx scripts/seed-e2e-cache.ts",
+    "e2e:serve": "tsx scripts/seed-e2e-cache.ts && tsx scripts/dev-server.ts start",
     "cache:check": "tsx scripts/check-app-cache.ts",
     "cache:check:deep": "tsx scripts/check-app-cache.ts --deep",
     "build": "next build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,10 @@ export default defineConfig({
     trace: "retain-on-failure",
   },
   webServer: {
-    command: `${pnpmCommand} dev`,
+    // Seed the synthetic contract cache BEFORE the managed dev server runs its app-ready
+    // preflight. Playwright starts webServer before globalSetup, so a fresh checkout (CI)
+    // has no cache when the server boots; `e2e:serve` seeds it first so the preflight passes.
+    command: `${pnpmCommand} e2e:serve`,
     url: "http://127.0.0.1:3000",
     reuseExistingServer: false,
     env: {

--- a/scripts/seed-e2e-cache.ts
+++ b/scripts/seed-e2e-cache.ts
@@ -1,0 +1,23 @@
+import path from "node:path";
+
+import { createSampleAppData } from "@/tests/helpers/app-data-fixture";
+
+/**
+ * Seeds the synthetic app-ready contract cache used by the Playwright e2e run.
+ *
+ * Playwright starts `webServer` (the managed `pnpm dev`, which runs the app-ready
+ * cache preflight) BEFORE `globalSetup` runs, so relying on `globalSetup` to build
+ * the fixture leaves a fresh checkout (e.g. CI) without a cache when the server
+ * boots and the preflight fails. Building the fixture here, ahead of the server
+ * (see `e2e:serve`), makes the preflight pass on a clean machine and in CI.
+ */
+async function main() {
+  const root = path.join(process.cwd(), ".local", "test-app-data", "v1");
+  await createSampleAppData(root);
+  console.log(`Seeded synthetic e2e app-data fixture at ${root}`);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -216,11 +216,13 @@ test("shows stockpile feed and discharge anchors on the pile view", async ({
   await page.goto("/live?view=piles&object=pile_stockpile");
 
   await expect(page.getByText("Feeds (2)")).toBeVisible();
-  await expect(page.getByText("Feed point west")).toBeVisible();
-  await expect(page.getByText("Feed point east")).toBeVisible();
+  // Scope the anchor-label assertions to the anchor spans: the currently-selected anchor also renders
+  // its label as an <h3> in the detail panel, so a bare getByText is ambiguous (strict-mode violation).
+  await expect(page.locator(".pile-anchor__label", { hasText: "Feed point west" })).toBeVisible();
+  await expect(page.locator(".pile-anchor__label", { hasText: "Feed point east" })).toBeVisible();
   await expect(page.getByText("Discharges (2)")).toBeVisible();
-  await expect(page.getByText("Reclaim west")).toBeVisible();
-  await expect(page.getByText("Reclaim east")).toBeVisible();
+  await expect(page.locator(".pile-anchor__label", { hasText: "Reclaim west" })).toBeVisible();
+  await expect(page.locator(".pile-anchor__label", { hasText: "Reclaim east" })).toBeVisible();
 });
 
 test("keeps simultaneous direct feeder evidence visible for multi-output live piles", async ({


### PR DESCRIPTION
The e2e job fails in CI because Playwright starts the webServer (pnpm dev + app-ready preflight) before globalSetup builds the fixture, so a fresh checkout has no manifest.json when the server boots (exit 1). Seeds the fixture ahead of the server via a new seed:e2e script + an e2e:serve webServer command. Verified locally on a wiped fixture: seed writes manifest.json and cache:check passes.